### PR TITLE
Added check if maintenance_until is not null

### DIFF
--- a/django_maintenance_window/management/commands/check_maintenance_mode.py
+++ b/django_maintenance_window/management/commands/check_maintenance_mode.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
         now = timezone.now()
 
         if config.maintenance:
-            if config.maintenance_until < now:
+            if config.maintenance_until and config.maintenance_until < now:
                 config.maintenance = False
                 config.maintenance_until = None
                 config.save()


### PR DESCRIPTION
The management command does not check whether the configured ``maintenance_until`` is empty, leading to a comparison error.